### PR TITLE
team member pagination fix

### DIFF
--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -102,19 +102,16 @@ class Approvals extends Validator {
       }
 
       try {
-        teamMembers = await Teams.extractTeamMembers(context, teams)
+        teamMembers = await Teams.hasAnyActiveTeamMembership(context, teams, approvedReviewers[0])
       } catch (err) {
-        if (err instanceof TeamNotFoundError) {
-          const validatorContext = { name: 'approvals' }
-          const output = [constructErrorOutput(validatorContext, teams, limitOption, `${err.name}`, err)]
-          return consolidateResult(output, validatorContext)
-        }
         throw err
       }
 
-      teamMembers = _.union(teamMembers, owners)
-
-      approvedReviewers = _.intersection(approvedReviewers, teamMembers)
+      // Approved user doesn't have an active teammembership within any defined teams,
+      // user will be removed from approvedReviews.
+      if (!teamMembers) {
+        approvedReviewers = _.intersection(approvedReviewers, teamMembers)
+      }
     }
 
     let output = await this.processOptions(validationSettings, approvedReviewers)

--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -95,22 +95,26 @@ class Approvals extends Validator {
     if (limitOption) {
       let owners = []
       let teams = []
-      let teamMembers = []
+      
       if (limitOption.teams) teams = teams.concat(limitOption.teams)
       if (limitOption.owners) {
         owners = await Owner.process(this.getPayload(context), context)
       }
 
-      try {
-        teamMembers = await Teams.hasAnyActiveTeamMembership(context, teams, approvedReviewers[0])
-      } catch (err) {
-        throw err
-      }
 
-      // Approved user doesn't have an active teammembership within any defined teams,
-      // user will be removed from approvedReviews.
-      if (!teamMembers) {
-        approvedReviewers = _.intersection(approvedReviewers, teamMembers)
+      for (let user of approvedReviewers) {
+        let isTeamMember = false
+        try {
+          isTeamMember = await Teams.hasAnyActiveTeamMembership(context, teams, user)
+        } catch (err) {
+          throw err
+        }
+
+        // Approved user doesn't have an active teammembership within any defined teams,
+        // user will be removed from approvedReviews.
+        if (!isTeamMember) {
+          approvedReviewers = _.intersection(approvedReviewers, user)
+        }
       }
     }
 

--- a/lib/validators/options_processor/teams.js
+++ b/lib/validators/options_processor/teams.js
@@ -19,6 +19,25 @@ class Teams {
     }
     return _.uniq(teamMembers)
   }
+
+  static async hasAnyActiveTeamMembership(context, teams, username) {
+    let membershipState
+
+    if (!teams || teams.length === 0) return teamMembers
+
+    for (let team of teams) {
+      let members = []
+      try {
+        membershipState = await getTeamMembershipState(context, team, username)
+
+        if (membershipState) { return true }
+      } catch (err) {
+        throw err
+      }
+    }
+     
+     return false
+  }
 }
 
 const getTeamMembers = async (context, team) => {
@@ -45,6 +64,37 @@ const getTeamMembers = async (context, team) => {
   }
 
   return res.data.map(member => member.login)
+}
+
+const getTeamMembershipState = async (context, team, username) => {
+  const stringArray = team.split('/')
+  if (stringArray.length !== 2) {
+    throw Error(`each team id needs to be given in 'org/team_slug'`)
+  }
+  if (stringArray[0].indexOf('@') === 0) stringArray[0] = stringArray[0].substring(1)
+
+  const org = stringArray[0]
+  const teamSlug = stringArray[1]
+
+  let res
+  try {
+    res = await context.github.teams.getMembershipInOrg({
+      org,
+      team_slug: teamSlug,
+      username: username
+    })
+  } catch (err) {
+    if (err.status === 404) {
+       return false
+    }
+    throw err
+  }
+
+  if (res.data.state === 'active') {
+    return true
+  }
+
+  return false
 }
 
 module.exports = Teams


### PR DESCRIPTION
Related issue: https://github.com/mergeability/mergeable/issues/442

This PR follows the second idea which I've changed the alghorithm to fetch approved users membership states and if any of them are true, it will be counted.

```
We can change alghoritm to rather than Listing all members, keeping in array and search in array, we can use getMembershipInOrg to fetch the approval user membership status in teams, if one of them returns 200 - active, we can return true or false.
```