### PR TITLE
codeowners team fix

### DIFF
--- a/lib/validators/approvals.js
+++ b/lib/validators/approvals.js
@@ -88,7 +88,7 @@ class Approvals extends Validator {
 
       if (limitOption.teams) teams = teams.concat(limitOption.teams)
       if (limitOption.owners) {
-        owners = await Owner.process(this.getPayload(context), context)
+        owners = await Owner.process(this.getPayload(context), context, approvedReviewers)
       }
 
       try {

--- a/lib/validators/options_processor/owners.js
+++ b/lib/validators/options_processor/owners.js
@@ -3,7 +3,7 @@ const Teams = require('./teams')
 const _ = require('lodash')
 
 class Owner {
-  static async process(payload, context, approvedReviewers) {
+  static async process (payload, context, approvedReviewers) {
     const CODEOWNERS = await retrieveCODEOWNER(context, payload.number)
 
     if (CODEOWNERS === null) return []

--- a/lib/validators/options_processor/owners.js
+++ b/lib/validators/options_processor/owners.js
@@ -3,7 +3,7 @@ const Teams = require('./teams')
 const _ = require('lodash')
 
 class Owner {
-  static async process (payload, context) {
+  static async process(payload, context, approvedReviewers) {
     const CODEOWNERS = await retrieveCODEOWNER(context, payload.number)
 
     if (CODEOWNERS === null) return []
@@ -34,12 +34,11 @@ class Owner {
     let teamMembers = []
     if (teams.length > 0) {
       try {
-        teamMembers = await Teams.extractTeamMemberships(context, teams, requiredIndividuals)
+        teamMembers = await Teams.extractTeamMemberships(context, teams, approvedReviewers)
       } catch (err) {
         throw err
       }
     }
-
     return _.union(teamMembers, requiredIndividuals)
   }
 


### PR DESCRIPTION
From today, we have figured out a problem with Mergeable, if you type a team name into codeowners, Mergeable couldn't extract team members from the team. That's because of we were sending wrong list to extractTeamMemberships method.

I've fixed it now and it's working as expected.