### PR TITLE
feat: Add chart support to prometheus servicemonitor

### DIFF
--- a/helm/mergeable/templates/prometheus-servicemonitor.yaml
+++ b/helm/mergeable/templates/prometheus-servicemonitor.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.prometheus.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    {{- include "mergeable.labels" $ | nindent 4 }}
+    prometheus: kube-prometheus
+  name: {{ include "mergeable.fullname" . }}
+spec:
+  endpoints:
+  - interval: {{ .Values.prometheus.service.metricInterval | default "30s" }}
+    path: {{ .Values.prometheus.service.metricPath | default "/metrics" }}
+    port: {{ .Values.prometheus.service.metricPortName | default "http" }}
+  jobLabel: {{ include "mergeable.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - "{{ $.Release.Namespace }}"
+  selector:
+    matchLabels:
+      app: {{ include "mergeable.fullname" . }}
+  sampleLimit: {{ .Values.prometheus.service.sampleLimit | default 5000}}
+{{- end }}

--- a/helm/mergeable/templates/service.yaml
+++ b/helm/mergeable/templates/service.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "mergeable.fullname" . }}
   labels:
     {{- include "mergeable.labels" . | nindent 4 }}
+    app: {{ include "mergeable.fullname" . }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/helm/mergeable/values.yaml
+++ b/helm/mergeable/values.yaml
@@ -87,6 +87,11 @@ affinity: {}
 
 prometheus:
   enabled: false
+  service: {}
+    # metricInterval: 30s
+    # metricPath: /metrics
+    # metricPortName: http
+    # sampleLimit: 5000
   rules: {}
     # - name: mergeable
     #   rules:


### PR DESCRIPTION
Currently, the chart does not support monitoring services.
This PR implements support.